### PR TITLE
Implement multi-window workspace for IDS mock UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
   <script type="text/babel" data-presets="react,env" src="./src/components/common/Label.jsx"></script>
   <script type="text/babel" data-presets="react,env" src="./src/components/metrics/CardMetric.jsx"></script>
   <script type="text/babel" data-presets="react,env" src="./src/components/alerts/AlertDetailModal.jsx"></script>
+  <script type="text/babel" data-presets="react,env" src="./src/components/layout/WindowFrame.jsx"></script>
   <script type="text/babel" data-presets="react,env" src="./src/components/layout/Sidebar.jsx"></script>
 
   <!-- Rutas -->

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
 (function () {
-  const { useState } = React;
+  const { useMemo, useState } = React;
 
   const Sidebar = window.Components?.Layout?.Sidebar;
+  const WindowFrame = window.Components?.Layout?.WindowFrame;
   const AlertDetailModal = window.Components?.Alerts?.AlertDetailModal;
   const { AuthProvider, AlertsProvider } = window.Context || {};
   const { useAuth, useAlerts } = window.Hooks || {};
@@ -11,25 +12,119 @@
   const AppShell = () => {
     const { isAuthenticated, login, logout } = useAuth();
     const { selectedAlert, setSelectedAlert } = useAlerts();
-    const [page, setPage] = useState('dashboard');
+    const availableWindows = useMemo(() => {
+      const registry = new Map();
+      const entries = AppRoutes?.all?.() || [];
+      entries.forEach((entry) => {
+        if (entry?.component) {
+          registry.set(entry.id, entry);
+        }
+      });
+      return registry;
+    }, []);
+
+    const defaultOrder = useMemo(() => {
+      const defaults = ['dashboard', 'alertas'];
+      const validDefaults = defaults.filter((id) => availableWindows.has(id));
+      if (validDefaults.length) {
+        return validDefaults;
+      }
+      if (availableWindows.size) {
+        const firstAvailable = availableWindows.keys().next().value;
+        return firstAvailable ? [firstAvailable] : [];
+      }
+      return [];
+    }, [availableWindows]);
+
+    const [openWindows, setOpenWindows] = useState(() => [...defaultOrder]);
+    const [activeWindow, setActiveWindow] = useState(defaultOrder[0] || null);
 
     if (!isAuthenticated) {
       return <LoginPage onLogin={login} />;
     }
 
-    const CurrentPage = AppRoutes?.(page);
+    const handleOpenWindow = (id) => {
+      if (!availableWindows.has(id)) {
+        return;
+      }
+      setOpenWindows((prev) => {
+        if (prev.includes(id)) {
+          const reordered = [...prev.filter((item) => item !== id), id];
+          return reordered;
+        }
+        return [...prev, id];
+      });
+      setActiveWindow(id);
+    };
+
+    const handleFocusWindow = (id) => {
+      if (availableWindows.has(id)) {
+        setActiveWindow(id);
+      }
+    };
+
+    const handleCloseWindow = (id) => {
+      setOpenWindows((prev) => {
+        const filtered = prev.filter((item) => item !== id);
+        if (prev.includes(id)) {
+          setActiveWindow((current) => {
+            if (current !== id) return current;
+            if (filtered.length) {
+              return filtered[filtered.length - 1];
+            }
+            return null;
+          });
+        }
+        return filtered;
+      });
+      if (id === 'alertas') {
+        setSelectedAlert(null);
+      }
+    };
 
     const handleLogout = () => {
       logout();
-      setPage('dashboard');
+      setOpenWindows([...defaultOrder]);
+      setActiveWindow(defaultOrder[0] || null);
       setSelectedAlert(null);
     };
 
+    const windowsToRender = openWindows
+      .map((id) => ({ id, config: availableWindows.get(id) }))
+      .filter(({ config }) => Boolean(config && config.component));
+
     return (
       <div className="flex h-screen bg-gray-900">
-        <Sidebar page={page} setPage={setPage} onLogout={handleLogout} />
-        <main className="flex-1 overflow-y-auto bg-gray-800/50">
-          {CurrentPage ? <CurrentPage onSelectAlert={setSelectedAlert} /> : null}
+        <Sidebar
+          activeWindow={activeWindow}
+          openWindows={openWindows}
+          onOpenWindow={handleOpenWindow}
+          onLogout={handleLogout}
+        />
+        <main className="flex-1 overflow-y-auto bg-gray-800/50 p-6">
+          {windowsToRender.length ? (
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+              {windowsToRender.map(({ id, config }) => {
+                const WindowComponent = config.component;
+                return (
+                  <WindowFrame
+                    key={id}
+                    title={config.label}
+                    isActive={activeWindow === id}
+                    onClose={() => handleCloseWindow(id)}
+                    onFocus={() => handleFocusWindow(id)}
+                    className="min-h-[26rem]"
+                  >
+                    <WindowComponent onSelectAlert={setSelectedAlert} />
+                  </WindowFrame>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-gray-700 text-gray-400">
+              Seleccione una ventana desde la barra lateral para comenzar.
+            </div>
+          )}
         </main>
         {selectedAlert && (
           <AlertDetailModal alert={selectedAlert} onClose={() => setSelectedAlert(null)} />

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,12 +1,28 @@
 (function () {
   window.Common = window.Common || {};
-  window.Common.Button = ({ children, onClick, className = '', type = 'button' }) => (
-    <button
-      type={type}
-      onClick={onClick}
-      className={`px-4 py-2 font-semibold text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors duration-300 ${className}`}
-    >
-      {children}
-    </button>
-  );
+  window.Common.Button = ({
+    children,
+    onClick,
+    className = '',
+    type = 'button',
+    disabled = false,
+    ...props
+  }) => {
+    const baseClasses =
+      'px-4 py-2 font-semibold text-white rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors duration-300';
+    const enabledClasses = 'bg-blue-600 hover:bg-blue-700 focus:ring-blue-500';
+    const disabledClasses = 'bg-blue-600 opacity-60 cursor-not-allowed';
+
+    return (
+      <button
+        type={type}
+        onClick={onClick}
+        disabled={disabled}
+        className={`${baseClasses} ${disabled ? disabledClasses : enabledClasses} ${className}`}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  };
 })();

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -3,7 +3,7 @@
   const { constants } = window.Config || {};
   const appName = constants?.APP_NAME || 'IDS Educativo';
 
-  const Sidebar = ({ page, setPage, onLogout }) => (
+  const Sidebar = ({ activeWindow, openWindows = [], onOpenWindow, onLogout }) => (
     <div className="flex flex-col w-64 bg-gray-900 text-gray-300">
       <div className="flex items-center justify-center h-20 border-b border-gray-800">
         <ShieldIcon className="w-8 h-8 text-blue-500" />
@@ -11,19 +11,35 @@
       </div>
       <nav className="flex-1 px-4 py-6 space-y-2">
         {(window.navigationItems || []).map((item) => {
-          const isActive = page === item.id;
+          const isActive = activeWindow === item.id;
+          const isOpen = openWindows.includes(item.id);
           const ItemIcon = item.icon;
           return (
             <button
               key={item.id}
               type="button"
-              onClick={() => setPage(item.id)}
-              className={`flex w-full items-center px-4 py-2.5 rounded-lg transition-colors duration-200 ${
-                isActive ? 'bg-blue-600 text-white' : 'hover:bg-gray-800'
+              onClick={() => onOpenWindow?.(item.id)}
+              className={`flex w-full items-center justify-between px-4 py-2.5 rounded-lg transition-colors duration-200 ${
+                isActive
+                  ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20'
+                  : isOpen
+                  ? 'bg-gray-800/70 text-white'
+                  : 'hover:bg-gray-800'
               }`}
             >
-              <ItemIcon className="w-5 h-5" />
-              <span className="ml-4 font-medium">{item.label}</span>
+              <span className="flex items-center">
+                {ItemIcon ? <ItemIcon className="w-5 h-5" /> : null}
+                <span className="ml-4 font-medium">{item.label}</span>
+              </span>
+              {isOpen && (
+                <span
+                  className={`text-xs font-semibold tracking-wide ${
+                    isActive ? 'text-blue-100' : 'text-blue-300'
+                  }`}
+                >
+                  {isActive ? 'Activa' : 'Abierta'}
+                </span>
+              )}
             </button>
           );
         })}

--- a/src/components/layout/WindowFrame.jsx
+++ b/src/components/layout/WindowFrame.jsx
@@ -1,0 +1,57 @@
+(function () {
+  const WindowFrame = ({
+    title,
+    children,
+    isActive = false,
+    onClose,
+    onFocus,
+    className = '',
+  }) => {
+    const handleClick = () => {
+      onFocus?.();
+    };
+
+    const handleClose = (event) => {
+      event.stopPropagation();
+      onClose?.();
+    };
+
+    return (
+      <section
+        className={`group relative flex h-full min-h-[22rem] flex-col overflow-hidden rounded-xl border bg-gray-900/80 backdrop-blur transition-all duration-200 ${
+          isActive
+            ? 'border-blue-500 shadow-lg shadow-blue-500/20'
+            : 'border-gray-800 hover:border-gray-700/70 hover:shadow-lg hover:shadow-blue-500/10'
+        } ${className}`}
+        onClick={handleClick}
+        onFocus={handleClick}
+        tabIndex={0}
+        role="group"
+      >
+        <header
+          className={`flex items-center justify-between border-b px-4 py-3 ${
+            isActive ? 'border-blue-500/40 bg-gray-900/70' : 'border-gray-800 bg-gray-900/50'
+          }`}
+        >
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-blue-400">Ventana</p>
+            <h2 className="text-sm font-bold text-white">{title}</h2>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="text-gray-500 transition-colors hover:text-white"
+            aria-label={`Cerrar ventana ${title}`}
+          >
+            ×
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto">{children}</div>
+      </section>
+    );
+  };
+
+  window.Components = window.Components || {};
+  window.Components.Layout = window.Components.Layout || {};
+  window.Components.Layout.WindowFrame = WindowFrame;
+})();

--- a/src/context/AlertsContext.jsx
+++ b/src/context/AlertsContext.jsx
@@ -1,24 +1,51 @@
 (function () {
-  const { createContext, useEffect, useMemo, useState } = React;
+  const { createContext, useCallback, useEffect, useMemo, useState } = React;
   const AlertsContext = createContext(null);
 
   const AlertsProvider = ({ children }) => {
     const [alerts, setAlerts] = useState(window.mockAlerts || []);
     const [selectedAlert, setSelectedAlert] = useState(null);
+    const [isLoading, setIsLoading] = useState(!Array.isArray(window.mockAlerts));
+    const [lastUpdated, setLastUpdated] = useState(null);
+
+    const fetchAlerts = useCallback(async () => {
+      const service = window.Services?.alertsService;
+      if (!service) return [];
+      const data = await service.fetchAlerts();
+      return Array.isArray(data) ? data : [];
+    }, []);
+
+    const refreshAlerts = useCallback(async () => {
+      setIsLoading(true);
+      try {
+        const data = await fetchAlerts();
+        setAlerts(data);
+        setLastUpdated(new Date().toISOString());
+        return data;
+      } finally {
+        setIsLoading(false);
+      }
+    }, [fetchAlerts]);
 
     useEffect(() => {
       let isMounted = true;
-      const loadAlerts = async () => {
-        const service = window.Services?.alertsService;
-        if (!service) return;
-        const data = await service.fetchAlerts();
-        if (isMounted) setAlerts(data);
+      const load = async () => {
+        setIsLoading(true);
+        try {
+          const data = await fetchAlerts();
+          if (isMounted) {
+            setAlerts(data);
+            setLastUpdated(new Date().toISOString());
+          }
+        } finally {
+          if (isMounted) setIsLoading(false);
+        }
       };
-      loadAlerts();
+      load();
       return () => {
         isMounted = false;
       };
-    }, []);
+    }, [fetchAlerts]);
 
     const value = useMemo(
       () => ({
@@ -26,8 +53,11 @@
         setAlerts,
         selectedAlert,
         setSelectedAlert,
+        refreshAlerts,
+        isLoading,
+        lastUpdated,
       }),
-      [alerts, selectedAlert],
+      [alerts, selectedAlert, refreshAlerts, isLoading, lastUpdated],
     );
 
     return <AlertsContext.Provider value={value}>{children}</AlertsContext.Provider>;

--- a/src/pages/AlertsPage.jsx
+++ b/src/pages/AlertsPage.jsx
@@ -2,20 +2,41 @@
   const { useAlerts } = window.Hooks || {};
   const { severityTheme } = window.Utils || {};
   const { formatDate } = window.Utils || {};
+  const { Button } = window.Common || {};
 
   const AlertsPage = ({ onSelectAlert }) => {
-    const { alerts, setSelectedAlert } = useAlerts();
+    const { alerts, setSelectedAlert, refreshAlerts, isLoading, lastUpdated } = useAlerts();
     const handleSelect = (alert) => {
       setSelectedAlert(alert);
       onSelectAlert?.(alert);
     };
 
     return (
-      <div className="p-8">
-        <h1 className="text-3xl font-bold text-white mb-6">Historial de Alertas</h1>
+      <div className="p-6">
+        <div className="flex flex-col gap-4 mb-6 lg:flex-row lg:items-center lg:justify-between">
+          <h1 className="text-3xl font-bold text-white">Historial de Alertas</h1>
+          <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+            <p className="text-sm text-gray-400">
+              Última actualización:{' '}
+              {lastUpdated
+                ? dayjs(lastUpdated).format('DD/MM/YYYY HH:mm:ss')
+                : isLoading
+                ? 'Actualizando…'
+                : 'Sin registros'}
+            </p>
+            <Button
+              onClick={refreshAlerts}
+              disabled={isLoading}
+              className="bg-gray-700 hover:bg-gray-600"
+            >
+              {isLoading ? 'Actualizando…' : 'Actualizar'}
+            </Button>
+          </div>
+        </div>
         <div className="bg-gray-800 rounded-lg shadow overflow-hidden">
-          <table className="w-full text-left text-sm text-gray-300">
-            <thead className="bg-gray-900/50 text-xs text-gray-400 uppercase tracking-wider">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left text-sm text-gray-300">
+              <thead className="bg-gray-900/50 text-xs text-gray-400 uppercase tracking-wider">
               <tr>
                 <th scope="col" className="px-6 py-3">
                   Criticidad
@@ -33,38 +54,53 @@
               </tr>
             </thead>
             <tbody>
-              {alerts.map((alert) => {
-                const theme = severityTheme?.[alert.criticidad] || severityTheme?.default || {};
-                return (
-                  <tr key={alert.id} className="border-b border-gray-700 hover:bg-gray-700/50">
-                    <td className="px-6 py-4">
-                      <span
-                        className={`px-2 py-1 text-xs font-semibold rounded-full border ${
-                          theme.border || 'border-gray-500/60'
-                        } ${theme.badge || 'bg-gray-500/20 text-gray-400'}`}
-                      >
-                        {alert.criticidad}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4">
-                      {formatDate?.(alert.timestamp)} ({dayjs(alert.timestamp).fromNow()})
-                    </td>
-                    <td className="px-6 py-4 font-medium">{alert.tipo}</td>
-                    <td className="px-6 py-4 font-mono">{alert.ipOrigen}</td>
-                    <td className="px-6 py-4 text-right">
-                      <button
-                        type="button"
-                        onClick={() => handleSelect(alert)}
-                        className="text-blue-400 hover:text-blue-300 font-semibold"
-                      >
-                        Ver Detalles
-                      </button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+              {isLoading && !alerts.length ? (
+                <tr>
+                  <td className="px-6 py-8 text-center text-gray-400" colSpan={5}>
+                    Cargando alertas recientes…
+                  </td>
+                </tr>
+              ) : alerts.length ? (
+                alerts.map((alert) => {
+                  const theme = severityTheme?.[alert.criticidad] || severityTheme?.default || {};
+                  return (
+                    <tr key={alert.id} className="border-b border-gray-700 hover:bg-gray-700/50">
+                      <td className="px-6 py-4">
+                        <span
+                          className={`px-2 py-1 text-xs font-semibold rounded-full border ${
+                            theme.border || 'border-gray-500/60'
+                          } ${theme.badge || 'bg-gray-500/20 text-gray-400'}`}
+                        >
+                          {alert.criticidad}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4">
+                        {formatDate?.(alert.timestamp)} ({dayjs(alert.timestamp).fromNow()})
+                      </td>
+                      <td className="px-6 py-4 font-medium">{alert.tipo}</td>
+                      <td className="px-6 py-4 font-mono">{alert.ipOrigen}</td>
+                      <td className="px-6 py-4 text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleSelect(alert)}
+                          className="text-blue-400 hover:text-blue-300 font-semibold"
+                        >
+                          Ver Detalles
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })
+              ) : (
+                <tr>
+                  <td className="px-6 py-8 text-center text-gray-400" colSpan={5}>
+                    No se encontraron alertas para el periodo seleccionado.
+                  </td>
+                </tr>
+              )}
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     );

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,5 +1,5 @@
 (function () {
-  const { useMemo, useState } = React;
+  const { useEffect, useMemo, useState } = React;
   const { Card } = window.Common || {};
   const { CardMetric } = window.Components?.Metrics || {};
   const { AlertTriangleIcon, CheckCircleIcon, XCircleIcon } = window.Icons || {};
@@ -27,37 +27,52 @@
   };
 
   const DashboardPage = () => {
-    const { alerts } = useAlerts();
+    const { alerts, lastUpdated, isLoading } = useAlerts();
     const [lastActivity, setLastActivity] = useState(dayjs());
 
-    useInterval?.(() => setLastActivity(dayjs()), constants?.REFRESH_INTERVAL_MS ?? 30 * 1000);
+    useInterval?.(
+      () => {
+        if (!lastUpdated) {
+          setLastActivity(dayjs());
+        }
+      },
+      constants?.REFRESH_INTERVAL_MS ?? 30 * 1000,
+    );
+
+    useEffect(() => {
+      if (lastUpdated) {
+        setLastActivity(dayjs(lastUpdated));
+      }
+    }, [lastUpdated]);
+
+    const normalizedAlerts = Array.isArray(alerts) ? alerts : [];
 
     const alertsToday = useMemo(
-      () => alerts.filter((alert) => dayjs(alert.timestamp).isSame(dayjs(), 'day')).length,
-      [alerts],
+      () => normalizedAlerts.filter((alert) => dayjs(alert.timestamp).isSame(dayjs(), 'day')).length,
+      [normalizedAlerts],
     );
 
     const healthStatus = useMemo(() => {
-      const hasHigh = alerts.some(
+      const hasHigh = normalizedAlerts.some(
         (alert) => alert.criticidad === 'Alta' && dayjs(alert.timestamp).isAfter(dayjs().subtract(1, 'hour')),
       );
-      const hasMedium = alerts.some(
+      const hasMedium = normalizedAlerts.some(
         (alert) => alert.criticidad === 'Media' && dayjs(alert.timestamp).isAfter(dayjs().subtract(1, 'hour')),
       );
       if (hasHigh) return { text: 'Alerta Crítica', color: 'bg-red-500', icon: XCircleIcon };
       if (hasMedium) return { text: 'Actividad Sospechosa', color: 'bg-yellow-500', icon: AlertTriangleIcon };
       return { text: 'Red Segura', color: 'bg-green-500', icon: CheckCircleIcon };
-    }, [alerts]);
+    }, [normalizedAlerts]);
 
     const alertTypesData = useMemo(() => {
-      const counts = alerts.reduce((acc, alert) => {
+      const counts = normalizedAlerts.reduce((acc, alert) => {
         acc[alert.tipo] = (acc[alert.tipo] || 0) + 1;
         return acc;
       }, {});
       const values = Object.values(counts);
       const max = values.length ? Math.max(...values) : 0;
       return { counts, max };
-    }, [alerts]);
+    }, [normalizedAlerts]);
 
     const trendData = useMemo(() => {
       const base = [
@@ -69,12 +84,13 @@
       return [...base, { periodo: 'Hoy', total: alertsToday }];
     }, [alertsToday]);
 
-    const HealthStatusIcon = healthStatus.icon;
+    const HealthStatusIcon = healthStatus.icon || CheckCircleIcon;
+    const lastUpdatedLabel = lastUpdated ? dayjs(lastUpdated).fromNow() : null;
 
     return (
-      <div className="p-8 space-y-8">
+      <div className="p-6 space-y-6">
         <h1 className="text-3xl font-bold text-white">Dashboard</h1>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className={`p-6 rounded-lg flex items-center justify-between text-white ${healthStatus.color}`}>
             <div>
               <p className="text-sm font-medium opacity-80">Estado de la Red</p>
@@ -82,20 +98,24 @@
             </div>
             <HealthStatusIcon className="w-10 h-10 opacity-70" />
           </div>
-          <CardMetric title="Alertas Hoy" value={alertsToday} />
-          <Card className="col-span-1 md:col-span-2">
+          <CardMetric title="Alertas Hoy" value={isLoading && !normalizedAlerts.length ? '—' : alertsToday} />
+          <Card className="md:col-span-2">
             <p className="text-sm font-medium text-gray-400">Última actividad analizada</p>
-            <p className="text-2xl font-bold text-white">{lastActivity.format('h:mm:ss A')}</p>
-            <p className="text-xs text-green-400">Sistema de Detección Activo</p>
+            <p className="text-2xl font-bold text-white">
+              {isLoading && !lastUpdated ? 'Cargando…' : lastActivity.format('h:mm:ss A')}
+            </p>
+            <p className="text-xs text-green-400">
+              {lastUpdatedLabel ? `Actualizado ${lastUpdatedLabel}` : 'Sistema de Detección Activo'}
+            </p>
           </Card>
         </div>
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <ServerStatusIndicator title="Uso de CPU" value={35} limit={100} />
           <ServerStatusIndicator title="Uso de Memoria" value={75} limit={100} />
           <ServerStatusIndicator title="Espacio en Disco" value={150} limit={250} />
           <CardMetric title="Versión del Sistema" value={constants?.VERSION || 'MVP'} tone="text-white" />
         </div>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
           <Card>
             <h2 className="text-lg font-semibold text-white mb-4">Resumen de Amenazas (Últimos 7 días)</h2>
             <div className="space-y-3">

--- a/src/pages/HelpPage.jsx
+++ b/src/pages/HelpPage.jsx
@@ -22,7 +22,7 @@
   };
 
   const HelpPage = () => (
-    <div className="p-8 text-white max-w-4xl mx-auto">
+    <div className="p-6 text-white max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold mb-2">Ayuda y Glosario</h1>
       <p className="text-gray-400 mb-8">
         Encuentre respuestas a preguntas frecuentes y aprenda sobre los tipos de amenazas.

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -5,19 +5,20 @@
 
   const ReportsPage = () => {
     const [reportVisible, setReportVisible] = useState(false);
-    const { alerts } = useAlerts();
+    const { alerts, lastUpdated } = useAlerts();
+    const dataset = Array.isArray(alerts) ? alerts : [];
 
     const alertTypesData = useMemo(() => {
-      const counts = alerts.reduce((acc, alert) => {
+      const counts = dataset.reduce((acc, alert) => {
         acc[alert.criticidad] = (acc[alert.criticidad] || 0) + 1;
         return acc;
       }, {});
       const total = Object.values(counts).reduce((sum, value) => sum + value, 0);
       return { counts, total };
-    }, [alerts]);
+    }, [dataset]);
 
     const topThreats = useMemo(() => {
-      const threats = alerts.reduce((acc, alert) => {
+      const threats = dataset.reduce((acc, alert) => {
         if (!acc[alert.tipo]) {
           acc[alert.tipo] = { tipo: alert.tipo, total: 0, ultima: alert.timestamp };
         }
@@ -30,10 +31,10 @@
       return Object.values(threats)
         .sort((a, b) => b.total - a.total)
         .slice(0, 5);
-    }, [alerts]);
+    }, [dataset]);
 
     return (
-      <div className="p-8 text-white">
+      <div className="p-6 text-white">
         <h1 className="text-3xl font-bold">Reportes de Seguridad</h1>
         <Card className="mt-6">
           <div className="flex items-center space-x-4">
@@ -52,6 +53,9 @@
         {reportVisible && (
           <div className="mt-8 bg-white text-black p-8 rounded-lg shadow-2xl max-w-4xl mx-auto modal-fade-in">
             <h2 className="text-2xl font-bold text-gray-800 mb-4">Resumen de Alertas por Criticidad</h2>
+            <p className="text-sm text-gray-500 mb-6">
+              Datos actualizados {lastUpdated ? dayjs(lastUpdated).fromNow() : 'recientemente'}.
+            </p>
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
               <div className="space-y-4">
                 <div className="bg-indigo-50 rounded-lg p-4">

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -13,7 +13,7 @@
     };
 
     return (
-      <div className="p-8 text-white max-w-4xl mx-auto">
+      <div className="p-6 text-white max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold mb-8">Configuración</h1>
         {notification && (
           <div

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,23 +1,52 @@
 (function () {
-  const AppRoutes = (page) => {
-    const { DashboardPage, AlertsPage, ReportsPage, SettingsPage, HelpPage } = window.Pages || {};
-    switch (page) {
-      case 'dashboard':
-        return DashboardPage;
-      case 'alertas':
-        return AlertsPage;
-      case 'reportes':
-        return ReportsPage;
-      case 'configuracion':
-        return SettingsPage;
-      case 'ayuda':
-        return HelpPage;
-      default:
-        return DashboardPage;
-    }
+  const getRouteComponent = {
+    dashboard: () => window.Pages?.DashboardPage,
+    alertas: () => window.Pages?.AlertsPage,
+    reportes: () => window.Pages?.ReportsPage,
+    configuracion: () => window.Pages?.SettingsPage,
+    ayuda: () => window.Pages?.HelpPage,
+  };
+
+  const getNavigationItems = () => window.navigationItems || [];
+
+  const buildRouteEntry = (id) => {
+    const navItem = getNavigationItems().find((item) => item.id === id);
+    const component = getRouteComponent[id]?.();
+    return component
+      ? {
+          id,
+          label: navItem?.label || id,
+          icon: navItem?.icon,
+          component,
+        }
+      : null;
+  };
+
+  const resolve = (pageId) => {
+    const fallbackId = 'dashboard';
+    const validId = getRouteComponent[pageId] ? pageId : fallbackId;
+    return buildRouteEntry(validId) || buildRouteEntry(fallbackId);
+  };
+
+  const all = () => {
+    const uniqueIds = Array.from(
+      new Set([
+        ...getNavigationItems()
+          .map((item) => item.id)
+          .filter((id) => Boolean(getRouteComponent[id])),
+        'dashboard',
+      ]),
+    );
+
+    return uniqueIds
+      .map((id) => buildRouteEntry(id))
+      .filter(Boolean);
   };
 
   window.Routes = window.Routes || {};
-  window.Routes.AppRoutes = AppRoutes;
+  window.Routes.AppRoutes = {
+    resolve,
+    all,
+  };
 })();
 


### PR DESCRIPTION
## Summary
- add a reusable WindowFrame layout and adapt the sidebar/routes so multiple sections can stay open at once
- refactor the app shell to manage opening, focusing, and closing windows while keeping alert detail state in sync
- tune each page layout and shared button styles to better fit inside the new windowed workspace, including scrollable tables where needed

## Testing
- not run (static front-end)


------
https://chatgpt.com/codex/tasks/task_e_68faed826ebc832fbe654ae259aca8a1